### PR TITLE
SSRF - Exercise 2

### DIFF
--- a/XSRF, SSRF, SSTI/SSRF2/backend/Dockerfile
+++ b/XSRF, SSRF, SSTI/SSRF2/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:7.4-apache
+
+RUN apt-get update && apt-get install -y openssh-client sshpass
+
+COPY site.php /var/www/html/index.php
+
+EXPOSE 80

--- a/XSRF, SSRF, SSTI/SSRF2/backend/site.php
+++ b/XSRF, SSRF, SSTI/SSRF2/backend/site.php
@@ -1,0 +1,7 @@
+<?php
+    if(isset($_GET['run'])) {
+        $cmd = $_GET['run'];
+        exec($cmd, $out);
+        print_r($out);
+    } 
+?>

--- a/XSRF, SSRF, SSTI/SSRF2/compose.yaml
+++ b/XSRF, SSRF, SSTI/SSRF2/compose.yaml
@@ -1,0 +1,12 @@
+version: '3.0'
+
+services:
+  backend:
+    build: ./backend
+    ports:
+    - 80:80
+
+  internal:
+    build: 
+      context: ./
+      dockerfile: ./internal/Dockerfile

--- a/XSRF, SSRF, SSTI/SSRF2/dict.txt
+++ b/XSRF, SSRF, SSTI/SSRF2/dict.txt
@@ -1,0 +1,10 @@
+Ail7ceiDil4AXae4ju9g
+asha5achiequeek6eiTh
+aeYichai6Zaef8Hae7zu
+aeNeiYi2tal5maig5gah
+Soocoole6OhquaengouR
+ua1seid5eiz9Peequ4Su
+efoo7wahCh6Loopeingo
+eiXairei8ooquae7aelu
+ciad2eeph1Quahthahth
+eipi1pee1aegoh9aaJ0D

--- a/XSRF, SSRF, SSTI/SSRF2/internal/Dockerfile
+++ b/XSRF, SSRF, SSTI/SSRF2/internal/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get install -y openssh-server
+
+WORKDIR .
+COPY dict.txt dict.txt
+
+RUN mkdir /var/run/sshd
+RUN echo "root:$(shuf -n 1 ./dict.txt)" | chpasswd
+RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+EXPOSE 22
+
+CMD ["/usr/sbin/sshd", "-D"]


### PR DESCRIPTION
SSRF ssh to get contents of a file at an internal service's container.

Info:
Using the **backend** container, execute a command that prints the contents of `/etc/shadow` in the **internal** container. You can resolve **internal** container via docker internal DNS. You receive a `dict.txt` with possible passwords, a backend endpoint with url param `/?run=`. The backend container contains an `ssh` client.